### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 20


### PR DESCRIPTION
There's no need to run dependabot checks since this project has been generated from vite-react-ts template that has the most recently updated dependencies. 

Therefore, this PR removes dependabot config files and prioritise merging changes from the template instead.